### PR TITLE
chore: add prophecy to build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
       run: composer config minimum-stability dev
     - name: Install the extension, its dev dependencies and phpunit if it's not required by the extension
       shell: bash
-      run: composer require --prefer-stable -W --no-interaction "${{ steps.extension.outputs.name }}:dev-${{ steps.extension.outputs.ref }} as v99.99.99" "phpunit/phpunit:*" ${{ steps.extension.outputs.dependencies }}
+      run: composer require --prefer-stable -W --no-interaction "${{ steps.extension.outputs.name }}:dev-${{ steps.extension.outputs.ref }} as v99.99.99" "phpunit/phpunit:*" "phpspec/prophecy:*" ${{ steps.extension.outputs.dependencies }}
     - name: Set phpunit coverage configuration
       shell: bash
       run: mv -n "${{ github.action_path }}/phpunit.xml" .


### PR DESCRIPTION
We are getting errors like:

https://github.com/oat-sa/extension-tao-mediamanager/runs/8246214084?check_suite_focus=true

```
1) oat\taoMediaManager\test\unit\model\mapper\MediaSourcePermissionsMapperTest::testMapWithAllPermissions
PHPUnit\Framework\Exception: This test uses TestCase::prophesize(), but phpspec/prophecy is not installed. Please run "composer require --dev phpspec/prophecy".
```

So we need to make sure we have this dependency in the build