### PR TITLE
fix: ignore migration scripts when performing code sniffing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ runs:
         for FILE in "${added_modified_files[@]}"; do
             EXT="${FILE##*.}"
             echo "Changed file: " $FILE ", extension: " $EXT
-            if [ "$EXT" == "php" ]; then
+            if [[ "$EXT" == "php" && $FILE != migrations/Version* ]]; then
               echo "src/${FILE}" >> "${FILELIST}"
               echo "File added to the file list: " $FILE
             fi


### PR DESCRIPTION
This PR aims to fix cases when the code sniffer complains about the autogenerated migration scripts, such as https://github.com/oat-sa/extension-parcc-tei/actions/runs/3337125393/jobs/5523078550.