### PR TITLE
Fix code coverage reports generation

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.event.label.name == 'sonar_check' || github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ inputs.php }}

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,35 @@ runs:
     - name: Install the extension, its dev dependencies and phpunit if it's not required by the extension
       shell: bash
       run: composer require --prefer-stable -W --no-interaction "${{ steps.extension.outputs.name }}:dev-${{ steps.extension.outputs.ref }} as v99.99.99" "phpunit/phpunit:~9" "phpspec/prophecy:~1" "squizlabs/php_codesniffer:~3" ${{ steps.extension.outputs.dependencies }} ${{ steps.extension.outputs.dev-dependencies }}
+    - uses: Ana06/get-changed-files@v2.2.0
+      id: files
+      if: github.event_name == 'pull_request'
+      with:
+        format: 'csv'
+    - name: Check the coding style
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        FILELIST=$(mktemp /tmp/psr12-check.XXXXXX)
+        mapfile -d ',' -t added_modified_files < <(printf '%s,' '${{ steps.files.outputs.added_modified }}')
+        for FILE in "${added_modified_files[@]}"; do
+            EXT="${FILE##*.}"
+            echo "Changed file: " $FILE ", extension: " $EXT
+            if [[ "$EXT" == "php" && $FILE != migrations/Version* ]]; then
+              echo "src/${FILE}" >> "${FILELIST}"
+              echo "File added to the file list: " $FILE
+            fi
+        done
+        if [ -s "${FILELIST}" ]; then
+            vendor/bin/phpcs --standard=PSR12 --exclude=PSR1.Classes.ClassDeclaration,Squiz.Classes.ValidClassName -v --file-list="${FILELIST}"
+            RETVAL=$?
+            echo "The following files were tested for PSR-12 errors:"; echo 
+            cat -n "$FILELIST"
+        else
+            echo "There are no changes in PHP files (no PSR-12 test performed)"
+        fi
+        rm "$FILELIST"
+        exit $RETVAL
     - name: Generate localization files
       if: ${{ steps.extension.outputs.node-version }}
       shell: bash
@@ -139,35 +168,6 @@ runs:
         echo "completed='true'" >> $GITHUB_OUTPUT
     - uses: codecov/codecov-action@v5
       if: ${{ inputs.coverage && steps.backend_test.outputs.completed }}
-    - uses: Ana06/get-changed-files@v2.2.0
-      id: files
-      if: github.event_name == 'pull_request'
-      with:
-        format: 'csv'
-    - name: Execute script for filter
-      if: github.event_name == 'pull_request'
-      shell: bash
-      run: |
-        FILELIST=$(mktemp /tmp/psr12-check.XXXXXX)
-        mapfile -d ',' -t added_modified_files < <(printf '%s,' '${{ steps.files.outputs.added_modified }}')
-        for FILE in "${added_modified_files[@]}"; do
-            EXT="${FILE##*.}"
-            echo "Changed file: " $FILE ", extension: " $EXT
-            if [[ "$EXT" == "php" && $FILE != migrations/Version* ]]; then
-              echo "src/${FILE}" >> "${FILELIST}"
-              echo "File added to the file list: " $FILE
-            fi
-        done
-        if [ -s "${FILELIST}" ]; then
-            vendor/bin/phpcs --standard=PSR12 --exclude=PSR1.Classes.ClassDeclaration,Squiz.Classes.ValidClassName -v --file-list="${FILELIST}"
-            RETVAL=$?
-            echo "The following files were tested for PSR-12 errors:"; echo 
-            cat -n "$FILELIST"
-        else
-            echo "There are no changes in PHP files (no PSR-12 test performed)"
-        fi
-        rm "$FILELIST"
-        exit $RETVAL
     - name: Fail the job if front-end tests weren't OK
       if: ${{ steps.extension.outputs.node-version }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -71,11 +71,11 @@ runs:
       run: composer require --prefer-stable -W --no-interaction "${{ steps.extension.outputs.name }}:dev-${{ steps.extension.outputs.ref }} as v99.99.99" "phpunit/phpunit:~9" "phpspec/prophecy:~1" "squizlabs/php_codesniffer:~3" ${{ steps.extension.outputs.dependencies }} ${{ steps.extension.outputs.dev-dependencies }}
     - uses: Ana06/get-changed-files@v2.2.0
       id: files
-      if: github.event_name == 'pull_request'
+      if: ${{ github.event_name == 'pull_request' }}
       with:
         format: 'csv'
     - name: Check the coding style
-      if: github.event_name == 'pull_request'
+      if: ${{ github.event_name == 'pull_request' && steps.files.outputs.added_modified != '' }}
       shell: bash
       run: |
         FILELIST=$(mktemp /tmp/psr12-check.XXXXXX)

--- a/action.yml
+++ b/action.yml
@@ -88,6 +88,7 @@ runs:
               echo "File added to the file list: " $FILE
             fi
         done
+        RETVAL=0
         if [ -s "${FILELIST}" ]; then
             vendor/bin/phpcs --standard=PSR12 --exclude=PSR1.Classes.ClassDeclaration,Squiz.Classes.ValidClassName -v --file-list="${FILELIST}"
             RETVAL=$?

--- a/action.yml
+++ b/action.yml
@@ -137,8 +137,8 @@ runs:
       run: |
         vendor/bin/phpunit --bootstrap bootstrap.php${{ inputs.coverage && ' --coverage-clover coverage.xml' }} "src/${{ inputs.test-suites-path }}"
         echo "completed='true'" >> $GITHUB_OUTPUT
-    - uses: codecov/codecov-action@v3
-      if: ${{ inputs.coverage && steps.files.backend_test.completed }}
+    - uses: codecov/codecov-action@v5
+      if: ${{ inputs.coverage && steps.backend_test.outputs.completed }}
     - uses: Ana06/get-changed-files@v2.2.0
       id: files
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
This PR fixes the condition that prevented to upload coverage reports to codecov.io.

It also moves the coding-style check step up, so that it is executed earlier, before any other test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use the latest versions of actions for improved reliability.
  * Consolidated and moved the PHP coding style check to run earlier in the workflow for pull requests.
  * Upgraded the code coverage upload step to a newer version and improved its conditional execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->